### PR TITLE
Fix bugs with temperature setting

### DIFF
--- a/PlaticaBot/ContentView.swift
+++ b/PlaticaBot/ContentView.swift
@@ -17,7 +17,7 @@ struct ContentView: View {
         NavigationStack {
             if key.key == "" {
 #if os(iOS)
-                iOSGeneralSettings(settingsShown: .constant(true), dismiss: false)
+                iOSGeneralSettings(settingsShown: .constant(true), temperature: $temperature, dismiss: false)
                 
 #else
                 Text ("Please set your key in Settings")

--- a/PlaticaBot/ContentView.swift
+++ b/PlaticaBot/ContentView.swift
@@ -11,7 +11,7 @@ struct ContentView: View {
     @State var settingsShown = false
     @Environment(\.openURL) var openURL
     @ObservedObject var key = openAIKey
-    @State var temperature: Float = 1.0
+    @Binding var temperature: Float
     
     var body: some View {
         NavigationStack {
@@ -38,6 +38,6 @@ struct ContentView: View {
 
 struct ContentView_Previews: PreviewProvider {
     static var previews: some View {
-        ContentView()
+        ContentView(temperature: .constant(1.0))
     }
 }

--- a/PlaticaBot/PlaticaBotApp.swift
+++ b/PlaticaBot/PlaticaBotApp.swift
@@ -20,11 +20,11 @@ struct PlaticaBotApp: App {
     
     var body: some Scene {
         WindowGroup {
-            ContentView()
+            ContentView(temperature: $temperature)
         }
         #if os(macOS)
         Window("Chat", id: "chat") {
-            ChatView (temperature: $temperature)
+            ChatView(temperature: $temperature)
         }
         Settings {
             SettingsView(settingsShown: .constant(true), temperature: $temperature, dismiss: false)


### PR DESCRIPTION
Found and fixed two bugs with the temperature setting

1. `@State var temperature: Float` was declared in both `ContentView` and `PlaticaBotApp` classes. `SettingsView` was bound to `temperature` in `PlaticaBotApp` but `ChatView` was bound to `temperature` in `ContentView`, so setting the `temperature` in the (macOS) settings window didn't actually have any effect, i.e. because there was no link between the `temperature` values in `SettingsView` and `ChatView`. Fixed by binding `temperature` in `ContentView` to `PlaticaBotApp`
2. `iOSGeneralSettings` initialization in `ContentView` didn't have the required temperature arg. Fixed by adding it.