### PR TITLE
Temperature setting has fixed increments and limited range

### DIFF
--- a/PlaticaBot/Settings.swift
+++ b/PlaticaBot/Settings.swift
@@ -36,7 +36,7 @@ struct GeneralSettings: View {
     var body: some View {
         Form {
             LabeledContent ("Temperature") {
-                Slider(value: $temperature, in: 0...2.0) {
+                Slider(value: $temperature, in: 0.4...1.6, step: 0.2) {
                     EmptyView()
                 } minimumValueLabel: {
                     Text("Focused").font(.footnote).fontWeight(.thin)


### PR DESCRIPTION
<img width="462" alt="Screenshot 2023-03-25 at 3 49 28 PM" src="https://user-images.githubusercontent.com/8458547/227747948-a15df926-df5a-4ed6-9dc0-6043ca4b34e6.png">

Can only select temperatures from [0.4, 0.6, 0.8, 1.0, 1.2, 1.4, 1.6]

Limited the range because the max and min values are interesting as a curiosity but not, I think, actually useful. I could be convinced that there are use cases for temperature=0, but temperature=2.0 produces gibberish.

Restricted the selectable values to fixed increments because I think it is "nicer". To be honest, the impetus for this is that it drove me crazy that once I moved the slider I could never get it back to 1.0, only 1.00324 or 0.99283