### PR TITLE
Improve prompt TextField

### DIFF
--- a/PlaticaBot/ChatView.swift
+++ b/PlaticaBot/ChatView.swift
@@ -301,18 +301,21 @@ struct ChatView: View {
 #if os(watchOS)
         TextField(store.interactions.count == 0 ? "Your Question" : "Follow up", text: $prompt)
 #else
-        HStack {
+        HStack (alignment: .bottom) {
             TextField(store.interactions.count == 0 ? "Your Question" : "Follow up", text: $prompt, axis: .vertical)
+#if os(iOS)
                 .textFieldStyle(.roundedBorder)
+#endif
             Button (action: acceptUserResponse) {
                 Image (systemName: "arrow.up.circle.fill")
                     .foregroundColor(Color.accentColor)
                     .font(.title2)
             }
             .buttonStyle(.plain)
+            .padding([.bottom], 2)
         }
         .padding ([.horizontal])
-        .padding ([.top], 4)
+        .padding ([.vertical], 4)
 #endif
     }
     
@@ -322,16 +325,6 @@ struct ChatView: View {
         .onSubmit {
             runQuery()
         }
-#if !os(watchOS)
-        .onChange(of: prompt) { newValue in
-            guard let newValueLastChar = newValue.last else { return }
-            if newValueLastChar == "\n" {
-                prompt.removeLast()
-                acceptUserResponse ()
-            }
-        }
-    #endif
-
     }
     
     var shareView: some View {


### PR DESCRIPTION
# iPhone
- added padding between textField and iPhone keyboard
- align TextField and Button to bottom so that button doesnt move when TextField expands
![IMG_928EA711A87A-1](https://user-images.githubusercontent.com/8458547/231022111-736d8bbd-96fc-4c5d-b364-7b0a2add521b.jpeg)

# Mac
- don't use roundedBorder style in macOS because roundedBorder macOS TextFields can't grow to more than one line

# remove onChange watch-for-newline
To allow user to more easily write multi-line prompts

In macOS, the return key automatically triggers onSubmit in TextField, so it isn't necessary. Users can write newlines with option+return after the removal.

In iOS there is now a dedicated "send" button, so isn't necessary. Using the "send" button to submit and the "return" key to enter a newline in the TextField matches the behaviour of other apps, such as Messages.
