### PR TITLE
Refactor Settings

### DIFF
--- a/PlaticaBot/ChatView.swift
+++ b/PlaticaBot/ChatView.swift
@@ -173,7 +173,7 @@ struct ChatView: View {
     @EnvironmentObject var settings: SettingsStorage
     @State var id: UUID
     @State var starDate = Date()
-    @State var chat = ChatGPT(key: SettingsStorage.getAPIKey())
+    @State var chat = ChatGPT(key: "")
     @State var prompt: String = ""
     @State var started = Date ()
     @ObservedObject var store = InteractionStorage ()
@@ -236,7 +236,7 @@ struct ChatView: View {
         prompt = ""
         store.interactions = []
         started = Date ()
-        chat = ChatGPT(key: settings.apiKey)
+        chat = ChatGPT(key: "")
     }
     
     func getMessageSummary () -> String {

--- a/PlaticaBot/ChatView.swift
+++ b/PlaticaBot/ChatView.swift
@@ -170,12 +170,10 @@ class SpeechDelegate: NSObject, AVSpeechSynthesizerDelegate {
 }
 
 struct ChatView: View {
+    @EnvironmentObject var settings: SettingsStorage
     @State var id: UUID
     @State var starDate = Date()
-    @State var chat = ChatGPT(key: openAIKey.key)
-    @Binding var temperature: Float
-    @ObservedObject var key = openAIKey
-    @Binding var newModel: Bool
+    @State var chat = ChatGPT(key: SettingsStorage.getAPIKey())
     @State var prompt: String = ""
     @State var started = Date ()
     @ObservedObject var store = InteractionStorage ()
@@ -196,14 +194,12 @@ struct ChatView: View {
     #endif
     
     
-    init (prime: Bool = false, temperature: Binding<Float>, newModel: Binding<Bool>) {
+    init (prime: Bool = false) {
         self._prime = State (initialValue: prime)
         self._id = State (initialValue: UUID())
-        _temperature = temperature
         _synthesizer = State (initialValue: AVSpeechSynthesizer())
         _synthesizerDelegate = State (initialValue: nil)
         let d = SpeechDelegate (speaking: .constant(nil))
-        _newModel = newModel
         _synthesizerDelegate = State (initialValue: d)
         synthesizer.delegate = synthesizerDelegate
     }
@@ -240,7 +236,7 @@ struct ChatView: View {
         prompt = ""
         store.interactions = []
         started = Date ()
-        chat = ChatGPT(key: key.key)
+        chat = ChatGPT(key: settings.apiKey)
     }
     
     func getMessageSummary () -> String {
@@ -267,9 +263,9 @@ struct ChatView: View {
         prompt = ""
         appended += 1
         Task {
-            chat.model = newModel ? "gpt-4-0314" : "gpt-3.5-turbo"
-            chat.key = openAIKey.key
-            switch await chat.streamChatText(copy, temperature: temperature) {
+            chat.model = settings.newModel ? "gpt-4-0314" : "gpt-3.5-turbo"
+            chat.key = settings.apiKey
+            switch await chat.streamChatText(copy, temperature: settings.temperature) {
             case .failure(let error):
                 appendAnswer("Communication Error:\n\(error.description)")
                 return
@@ -419,8 +415,8 @@ struct ChatView: View {
                 ControlGroup {
                     shareView
                     Menu (content: {
-                        Button (action: { newModel.toggle() }) {
-                            Text ("Toggle Engine - " + (newModel ? "GPT4" : "GPT3"))
+                        Button (action: { settings.newModel.toggle() }) {
+                            Text ("Toggle Engine - " + (settings.newModel ? "GPT4" : "GPT3"))
                         }
                         Button (action: { showSettings = true }) {
                             Text ("Settings")
@@ -437,7 +433,7 @@ struct ChatView: View {
         }
         #if os(iOS)
         .sheet (isPresented: $showSettings) {
-            iOSGeneralSettings(settingsShown: $showSettings, temperature: $temperature, newModel: $newModel, dismiss: true)
+            iOSGeneralSettings(settingsShown: $showSettings, dismiss: true)
         }
         .sheet (isPresented: $showHistory) {
             HistoryView ()
@@ -455,6 +451,7 @@ struct ChatView: View {
 
 struct ChatView_Previews: PreviewProvider {
     static var previews: some View {
-        ChatView(prime: true, temperature: .constant(1.0), newModel: .constant(false))
+        ChatView(prime: true)
+            .environmentObject(SettingsStorage.preview)
     }
 }

--- a/PlaticaBot/ContentView.swift
+++ b/PlaticaBot/ContentView.swift
@@ -8,17 +8,14 @@
 import SwiftUI
 import Foundation
 struct ContentView: View {
-    @State var settingsShown = false
+    @EnvironmentObject var settings: SettingsStorage
     @Environment(\.openURL) var openURL
-    @ObservedObject var key = openAIKey
-    @Binding var temperature: Float
-    @Binding var newModel: Bool
     
     var body: some View {
         NavigationStack {
-            if key.key == "" {
+            if settings.apiKey == "" {
 #if os(iOS)
-                iOSGeneralSettings(settingsShown: .constant(true), temperature: $temperature, newModel: $newModel, dismiss: false)
+                iOSGeneralSettings(settingsShown: .constant(true), dismiss: false)
                 
 #else
                 Text ("Please set your key in Settings")
@@ -31,7 +28,7 @@ struct ContentView: View {
                 }
 #endif
             } else {
-                ChatView (temperature: $temperature, newModel: $newModel)
+                ChatView ()
             }
         }
     }
@@ -39,6 +36,7 @@ struct ContentView: View {
 
 struct ContentView_Previews: PreviewProvider {
     static var previews: some View {
-        ContentView(temperature: .constant(1.0), newModel: .constant(false))
+        ContentView()
+            .environmentObject(SettingsStorage.preview)
     }
 }

--- a/PlaticaBot/PlaticaBotiOS.swift
+++ b/PlaticaBot/PlaticaBotiOS.swift
@@ -9,12 +9,12 @@ import SwiftUI
 
 @main
 struct PlaticaBotApp: App {
-    @State var temperature: Float = 1.0
-    @State var newModel = false
-    
+    @StateObject private var settings = SettingsStorage()
+
     var body: some Scene {
         WindowGroup (id: "chat") {
-            ContentView(temperature: $temperature, newModel: $newModel)
+            ContentView()
+                .environmentObject(settings)
         }
     }
 }

--- a/PlaticaBot/Settings.swift
+++ b/PlaticaBot/Settings.swift
@@ -50,7 +50,7 @@ class SettingsStorage: ObservableObject {
     
     init() {
         self.apiKey = keyValueStore.string(forKey: APIKeyKey) ?? ""
-        self.temperature = keyValueStore.object(forKey: temperatureKey) as? Float ?? 0.8
+        self.temperature = keyValueStore.object(forKey: temperatureKey) as? Float ?? 1.0
         self.newModel = keyValueStore.bool(forKey: modelKey)
 #if os(macOS)
         self.showDockIcon = keyValueStore.bool(forKey: showDockIconKey)

--- a/PlaticaBot/Settings.swift
+++ b/PlaticaBot/Settings.swift
@@ -21,9 +21,6 @@ class SettingsStorage: ObservableObject {
             keyValueStore.synchronize()
         }
     }
-    static func getAPIKey() -> String {
-        return NSUbiquitousKeyValueStore.default.string(forKey: "OpenAI-key") ?? ""
-    }
     private let temperatureKey = "Temperature-key"
     @Published var temperature: Float {
         didSet {
@@ -65,7 +62,7 @@ class SettingsStorage: ObservableObject {
 
 struct GeneralSettings: View {
     @EnvironmentObject var settings: SettingsStorage
-    @State var apiKey: String = SettingsStorage.getAPIKey()
+    @State var apiKey: String = ""
     @Binding var settingsShown: Bool
     var dismiss: Bool
     
@@ -86,6 +83,9 @@ struct GeneralSettings: View {
             }.padding([.leading, .trailing])
             VStack (alignment: .leading) {
                 TextField ("OpenAI Key", text: $apiKey)
+                    .onAppear {
+                        apiKey = settings.apiKey
+                    }
                     .onSubmit {
                         settings.apiKey = apiKey
                     }

--- a/PlaticaWatch Watch App/ContentView.swift
+++ b/PlaticaWatch Watch App/ContentView.swift
@@ -10,7 +10,7 @@ import SwiftUI
 struct ContentView: View {
     var body: some View {
         NavigationStack {
-            ChatView(temperature: .constant(1.0), newModel: .constant(false))
+            ChatView()
         }
     }
 }

--- a/PlaticaWatch Watch App/PlaticaWatchApp.swift
+++ b/PlaticaWatch Watch App/PlaticaWatchApp.swift
@@ -9,12 +9,12 @@ import SwiftUI
 
 @main
 struct PlaticaWatch_Watch_AppApp: App {
+    @StateObject private var settings = SettingsStorage()
+
     var body: some Scene {
         WindowGroup {
             ContentView()
-                .onAppear {
-                    let key = getOpenAIKey()
-                }
+                .environmentObject(settings)
         }
     }
 }


### PR DESCRIPTION
This PR improves the passing of settings values from `GeneralSettings` to `ChatView`. Previously, these values were passed up and down the view hierarchy using `@State` and `@Binding` vars in each view along the path. By using `@EnvironmentObject` we can clean up vars and parameters in the daisy chain connecting the views which actually use the values.

The newly created `SettingsStorage` class, created to fill the role of `@EnvironmentObject` can also neatly encapsulate all the code for persisting settings to `NSUbiquitousKeyValueStore`

`setApplicationActivationPolicy()` has been moved from Settings.swift to PlaticaBotMac.swift to be with the other MacOS specific NSApplication code, because it is now easy to access `showDockIcon` with the `@ EnvironmentObject `

This PR is largely a pure refactor, but it makes a few minor functional changes as well, all related to settings:
- `temperature` and `newModel` settings are now persisted with `NSUbiquitousKeyValueStore` for consistency with other settings
- minimum temperature lowered from 0.4 to 0.0
- fixed the iOS preview in Settings.swift to show the view as it appears in iOS
- Watch app now uses the `temperature` and `newModel` settings from macOS or iOS.