### PR TITLE
Stop autoscroll when user starts scrolling

### DIFF
--- a/PlaticaBot/ChatView.swift
+++ b/PlaticaBot/ChatView.swift
@@ -231,7 +231,9 @@ struct ChatView: View {
     @State var showSettings: Bool = false
     @State var showHistory: Bool = false
     @State var chatInteraction: Interaction? = nil
+    #if os(iOS)
     private var scrollViewDelegate = ScrollViewDelegate()
+    #endif
     
     #if os(tvOS) || os(iOS)
     @State var sc: UIScrollView? = nil

--- a/PlaticaBot/ChatView.swift
+++ b/PlaticaBot/ChatView.swift
@@ -162,19 +162,33 @@ extension UIScrollView {
     }
 }
 class ScrollViewDelegate: NSObject, UIScrollViewDelegate {
-    var onDrag: (()->Void)? = nil
-    var onBounce: (()->Void)? = nil
+    private var contentHeightWhenDragEnded: CGFloat?
 
+    var onDrag: (()->Void)? = nil
+    var onBottomReached: (()->Void)? = nil
+
+    /// disable autoscroll when user starts manually scrolling
     func scrollViewWillBeginDragging(_ scrollView: UIScrollView) {
         onDrag?()
     }
-    
+
+    /// resume autoscroll when user scrolls back down to bottom
     func scrollViewWillEndDragging(_ scrollView: UIScrollView, withVelocity velocity: CGPoint, targetContentOffset: UnsafeMutablePointer<CGPoint>) {
         let bottomEdge = scrollView.contentOffset.y + scrollView.frame.size.height
         if bottomEdge >= scrollView.contentSize.height {
-            onBounce?()
+            onBottomReached?()
         }
+        contentHeightWhenDragEnded = scrollView.contentSize.height
     }
+    func scrollViewDidEndDecelerating(_ scrollView: UIScrollView) {
+        let bottomEdge = scrollView.contentOffset.y + scrollView.frame.size.height
+        if let contentHeightWhenDragEnded = self.contentHeightWhenDragEnded,
+           bottomEdge >= contentHeightWhenDragEnded {
+            onBottomReached?()
+        }
+        contentHeightWhenDragEnded = nil
+    }
+    
 }
 #endif
 
@@ -387,7 +401,7 @@ struct ChatView: View {
                 .introspectScrollView { sc in
                     self.sc = sc
                     self.scrollViewDelegate.onDrag = { self.stopAutoscroll = true }
-                    self.scrollViewDelegate.onBounce = { self.stopAutoscroll = false }
+                    self.scrollViewDelegate.onBottomReached = { self.stopAutoscroll = false }
                     self.sc?.delegate = scrollViewDelegate
                 }
                 .onChange(of: appended, perform: { value in


### PR DESCRIPTION
addressing /issues/1

ScrollViewDelegate watches user drag actions
- when user starts dragging, it stops autoscroll, so they can scroll freely
- when user stops dragging, if they scrolled back down to the bottom, it restarts autoscroll
- (autoscroll also restarts whenever a new prompt is sent)

Notes:
- iOS only, because it uses the introspected UIScrollView
- it feels bad and inefficient to rerun the introspectScrollView block every time the view reloads, but I guess that's the standard SwiftUI pattern
- it's pretty simple to disable autoscroll when user starts dragging the scroll view, but there are complications with resuming autoscroll when user scrolls back down to bottom.
    - iOS dragging has momentum, so users can release the drag gesture before they've actually reached the bottom and expect scroll to reach bottom, so we should check for bottom in `scrollViewDidEndDecelerating`, when the scroll actually ends, not just when drag ends
    - the bottom of the view is a moving target if ChatGPT is in the middle of replying, so in practice I found I was trying to scroll to the bottom and coming up short
    - the solution I arrived at was to check where the bottom is in `scrollViewWillEndDragging` and use that bottom offset as the target in `scrollViewDidEndDecelerating`
    - an alternative would be to add some kind of padding to the "bottom" offset so that autoscroll restarts when user just scrolls close to the bottom