### PR TITLE
Disable autoscroll when user tries to scroll up on macOS

### DIFF
--- a/PlaticaBot/ChatView.swift
+++ b/PlaticaBot/ChatView.swift
@@ -394,11 +394,14 @@ struct ChatView: View {
                         }
                         if let chatInteraction {
                             InteractionView(interaction: chatInteraction, synthesizer: $synthesizer, speaking: $speaking)
-                                .id (10)
+                                .id(chatInteraction.id)
                         }
                     }
+                    .id(UUID())
                     .padding ([.horizontal])
                 }
+                .id(UUID())
+
                 .scrollDismissesKeyboard(.interactively)
 #if os(iOS) || os(tvOS)
                 .introspectScrollView { sc in
@@ -415,8 +418,8 @@ struct ChatView: View {
                 })
 #elseif os(macOS) || os(watchOS)
                 .onChange(of: appended, perform: { value in
-                    if let last = store.interactions.last {
-                        proxy.scrollTo(10, anchor: .bottom)
+                    if let chatInteraction {
+                        proxy.scrollTo(chatInteraction.id, anchor: .bottom)
                     }
                 })
 #endif

--- a/PlaticaBot/ChatView.swift
+++ b/PlaticaBot/ChatView.swift
@@ -232,13 +232,11 @@ struct ChatView: View {
     @State var showHistory: Bool = false
     @State var chatInteraction: Interaction? = nil
     @State var serial = 1
-    #if os(iOS)
-    private var scrollViewDelegate = ScrollViewDelegate()
-    #endif
-    
     #if os(tvOS) || os(iOS)
     @State var sc: UIScrollView? = nil
+    private var scrollViewDelegate = ScrollViewDelegate()
     #endif
+    private let ScrollViewID = UUID()
     
     
     init (prime: Bool = false) {
@@ -377,10 +375,40 @@ struct ChatView: View {
                   preview: SharePreview("PlaticaBot", icon: Image (systemName: "tortoise.fill")))
     }
     
+    private struct OffsetReaderView: View {
+        @State var onScrollUp: ()->Void
+        @State private var prevOffset:CGFloat = .zero
+
+        private struct OffsetPreferenceKey: PreferenceKey {
+            static var defaultValue: CGFloat = .zero
+            static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {}
+        }
+        
+        var body: some View {
+            GeometryReader { proxy in
+                Color.clear
+                    .preference(
+                        key: OffsetPreferenceKey.self,
+                        value: proxy.frame(in: .named("frameLayer")).minY
+                    )
+            }
+            .frame(height:0)
+            .onPreferenceChange(OffsetPreferenceKey.self, perform: { offset in
+                if prevOffset < offset {
+                    onScrollUp()
+                }
+                prevOffset = offset
+            })
+        }
+    }
+
     var body: some View {
         VStack (alignment: .leading) {
             ScrollViewReader { proxy in
                 ScrollView  {
+                    #if os(macOS)
+                    OffsetReaderView(onScrollUp: { stopAutoscroll = true })
+                    #endif
                     VStack {
                         SingleInteractionView (color: assistantColor) {
                             Image (systemName: "brain")
@@ -400,7 +428,8 @@ struct ChatView: View {
                     .id(UUID())
                     .padding ([.horizontal])
                 }
-                .id(UUID())
+                .id(ScrollViewID)
+                .coordinateSpace(name: "frameLayer")
 
                 .scrollDismissesKeyboard(.interactively)
 #if os(iOS) || os(tvOS)
@@ -418,7 +447,7 @@ struct ChatView: View {
                 })
 #elseif os(macOS) || os(watchOS)
                 .onChange(of: appended, perform: { value in
-                    if let chatInteraction {
+                    if !stopAutoscroll, let chatInteraction {
                         proxy.scrollTo(chatInteraction.id, anchor: .bottom)
                     }
                 })


### PR DESCRIPTION
As in iOS, if user tries to scroll up while receiving a response from ChatGPT, it will disable autoscroll.
Unlike iOS, if user scrolls back down to the bottom, it won't restart autoscroll, until they send another prompt. I couldn't make this "feel" good, and it's not as necessary as in iOS because macOS's larger windows don't autoscroll as aggressively.

Uses a transparent 0 height GeometryReader to measure the offset of the top of the conversation from the top of the ScrollView, and uses the delta when that offset changes to determine if it is being scrolled upwards. This is pure platform independent SwiftUI and theoretically should also work with iOS, but in practice I spent a lunch hour trying and failing to make it work as well as the current UIScrollView approach.

oddities of note:
- `ScrollViewReader proxy.scrollTo(view.id)` doesn't work unless the view, and all subviews in the hierarchy between it and ScrollViewReader are explicitly assigned an id with `.id(...)`
- `ScrollView` must be assigned a fixed id (e.g. not `.id(UUID())` which generates a new id every time the view reloads) or the scroll offset will intermittently reset to 0